### PR TITLE
fixed cacheCooldown call in scanItemTooltip function

### DIFF
--- a/CraftCooldown.lua
+++ b/CraftCooldown.lua
@@ -414,8 +414,9 @@ function scanItemTooltip()
 						seconds = seconds + val * s
 					end
 				end
+				local skillName = GameTooltipTextLeft1:GetText()
 				cacheCooldown(skillName, time() + seconds)
-				printSkill(GameTooltipTextLeft1:GetText(), seconds)
+				printSkill(skillName, seconds)
 				-- printCached()
 				return
 			end


### PR DESCRIPTION
Without this change, the "cacheCooldown" function is called with the global variable "skillName" that can be any tradeskill that has been recently put into that variable - but it does not take the name from the tooltip that has just been scanned.
With this change, the skill from the tooltip is read and saved into a local variable "skillName" which is then used to correctly cache it.